### PR TITLE
Add struct parsing / evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,31 @@ var a = 10
 var c = "some string"
 var arrayValue = [1, 2, 3]
 
-var add = func(a, b) {
+func add(a, b) {
     return a + b
 }
 
-var isBigger = func(a, b) {
+func isBigger(a, b) {
     return a > b
 }
 
-var equal = func(a, b) {
-    return a == b
+struct Data { 
+    func init(a, b, c) {
+        this.a = a
+        this.c = a + b
+    }
+    
+    func doSomething() {
+        return a + c 
+    } 
 }
+// STRUCT_DECL: struct Identifier BLOCK
+// BLOCK: { functions* } 
+
+// 
+// var data = new Data(a, b, c)
+
+// data.doSomething()
 
 // Object declaration
 var object = new()

--- a/debug/printer.go
+++ b/debug/printer.go
@@ -13,6 +13,14 @@ type PrintingVisitor struct {
 	buffer bytes.Buffer
 }
 
+func (p *PrintingVisitor) VisitStructDeclaration(statement parser.StructDeclarationStatement) {
+	p.printIndent()
+	p.buffer.WriteString(fmt.Sprintf("StructDeclaration %s", statement.Name))
+	for _, method := range statement.Methods {
+		p.VisitFunctionStatement(*method)
+	}
+}
+
 func (p *PrintingVisitor) VisitArrayAccess(access parser.IndexAccess) {
 	p.printIndent()
 	p.buffer.WriteString("IndexAccess")

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -77,7 +77,7 @@ func TestLexer_Next(t *testing.T) {
 			NewToken(Comma, ","),
 			NewToken(Identifier, "a"),
 		}},
-		{`func new return if else a for var true false in`, []Token{
+		{`func new return if else a for var true false in new struct`, []Token{
 			NewToken(Func, "func"),
 			NewToken(New, "new"),
 			NewToken(Return, "return"),
@@ -89,6 +89,8 @@ func TestLexer_Next(t *testing.T) {
 			NewToken(True, "true"),
 			NewToken(False, "false"),
 			NewToken(In, "in"),
+			NewToken(New, "new"),
+			NewToken(Struct, "struct"),
 		}},
 		{`func main(a, b) {
 	var a = a[0]

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -72,6 +72,7 @@ const (
 	// Keywords
 	Func   = "func"
 	New    = "new"
+	Struct = "struct"
 	Return = "return"
 	Var    = "var"
 	True   = "true"
@@ -97,6 +98,7 @@ const (
 var Keywords = map[string]TokenType{
 	"func":   Func,
 	"new":    New,
+	"struct": Struct,
 	"return": Return,
 	"var":    Var,
 	"true":   True,

--- a/parser/node.go
+++ b/parser/node.go
@@ -36,6 +36,7 @@ type NodeVisitor interface {
 	VisitIfStatement(IfStatement)
 	VisitFunctionStatement(FunctionStatement)
 	VisitForStatement(ForStatement)
+	VisitStructDeclaration(StructDeclarationStatement)
 }
 
 type Node interface {
@@ -425,4 +426,21 @@ func (i *IndexAccess) Statement() {
 
 func (i *IndexAccess) Expr() {
 	panic("implement me")
+}
+
+type StructDeclarationStatement struct {
+	Name    string
+	Methods []*FunctionStatement
+}
+
+func (s *StructDeclarationStatement) Statement() {
+	panic("implement me")
+}
+
+func (s *StructDeclarationStatement) Literal() string {
+	panic("implement me")
+}
+
+func (s *StructDeclarationStatement) Accept(visitor NodeVisitor) {
+	visitor.VisitStructDeclaration(*s)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -183,6 +183,8 @@ func (p *Parser) parseStatement() Statement {
 		return p.parseFunctionStatement()
 	case lexer.For:
 		return p.parseForStatement()
+	case lexer.Struct:
+		return p.parseStructDeclaration()
 	default:
 		return p.parseExpression()
 	}
@@ -468,4 +470,28 @@ func (p *Parser) parseArrayAccess(left Expression) Expression {
 	indexAccess.Index = p.parseExpression()
 	p.expectNext(lexer.CloseBracket)
 	return indexAccess
+}
+
+func (p *Parser) parseStructDeclaration() Statement {
+	structDec := &StructDeclarationStatement{}
+	p.advance() // skip the struct keyword
+	structDec.Name = p.CurrentToken.Literal
+	p.advance() // skip the literal
+	functions := make([]*FunctionStatement, 0)
+	p.advanceExpect(lexer.OpenBrace) // skip the opening brace
+	for {
+		if p.CurrentToken.Type == lexer.CloseBrace {
+			break
+		}
+		funcStatement := p.parseFunctionStatement()
+		funcCasted, ok := funcStatement.(*FunctionStatement)
+		if !ok {
+			p.Errors.Report(p.CurrentToken, "Expected a function declaration")
+			return structDec
+		}
+		functions = append(functions, funcCasted)
+	}
+	structDec.Methods = functions
+	p.advanceExpect(lexer.CloseBrace)
+	return structDec
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -490,8 +490,8 @@ func (p *Parser) parseStructDeclaration() Statement {
 			return structDec
 		}
 		functions = append(functions, funcCasted)
+		p.advanceExpect(lexer.CloseBrace)
 	}
 	structDec.Methods = functions
-	p.advanceExpect(lexer.CloseBrace)
 	return structDec
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1115,6 +1115,24 @@ func TestParser_Parse_ParseStructDeclaration(t *testing.T) {
 			Expr: `
 			struct Data { 
 				func init() {}
+				func testa() {}
+			}
+			func two() { } 
+		 `,
+			Expected: []Node{
+				&StructDeclarationStatement{Name: "Data"},
+				&FunctionStatement{Name: "init"},
+				&BlockStatement{},
+				&FunctionStatement{Name: "testa"},
+				&BlockStatement{},
+				&FunctionStatement{Name: "two"},
+				&BlockStatement{},
+			},
+		},
+		{
+			Expr: `
+			struct Data { 
+				func init() {}
 			}
 			func two() { } 
 		 `,

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -30,7 +30,7 @@ func (r *Repl) Start(reader io.Reader, writer io.Writer) {
 				break
 			}
 			if line == "/scope" {
-				printScope(evaluator.Scope)
+				printScope(evaluator)
 				continue
 			}
 		}
@@ -47,10 +47,16 @@ func (r *Repl) Start(reader io.Reader, writer io.Writer) {
 	}
 }
 
-func printScope(scope *eval.Scope) {
+func printScope(eval *eval.Evaluator) {
+	fmt.Println("==== Variables ====")
+	scope := eval.Scope
 	for cur := scope; cur != nil; cur = cur.Parent {
 		for k, v := range cur.Variables {
 			fmt.Println(fmt.Sprintf("%s = %v", k, v.Type()))
 		}
+	}
+	fmt.Println("==== Types ====")
+	for _, t := range eval.Types {
+		fmt.Println(t.Name)
 	}
 }

--- a/std/types.go
+++ b/std/types.go
@@ -2,6 +2,7 @@ package std
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"github.com/chermehdi/comet/parser"
 )
@@ -126,6 +127,7 @@ func (c *CometReturnWrapper) ToString() string {
 }
 
 type CometFunc struct {
+	Name   string
 	Params []*parser.IdentifierExpression
 	Body   *parser.BlockStatement
 }
@@ -157,4 +159,25 @@ func CreateError(s string, params ...interface{}) CometObject {
 	return &CometError{
 		message,
 	}
+}
+
+// CometStruct represents a struct declaration in the comet language.
+type CometStruct struct {
+	Name    string
+	Methods []*CometFunc
+}
+
+// Add adds a method to a struct with performing sanity checks according to the
+// language rules.
+func (s *CometStruct) Add(fn *CometFunc) error {
+	for _, m := range s.Methods {
+		if m.Name == fn.Name {
+			// As Comet is not typed it does not make sense to have method overloading
+			// as A(1, 2) is equivalenet to A(1, 2, "") because no argument checking
+			// is performed in the current implementation.
+			return errors.New(fmt.Sprintf("Method already exist with the name '%s' on '%s' struct", m.Name, s.Name))
+		}
+	}
+	s.Methods = append(s.Methods, fn)
+	return nil
 }


### PR DESCRIPTION
 Struct declarations are evaluated and registered as global type definitions in the evaluator.

Future improvements should include:
1. Add proper scoping and namespacing for struct declarations.
1. Report an error on redeclaration of the a struct in the same (module,
       name)
